### PR TITLE
Updated example to use API key, paygo.crawlera.com and different target URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,8 +46,8 @@ layout: default
     </p>
 
     <h3>Example</h3>
-    <p>Using Crawlera can be as easy as running following command:
-    <pre>  curl -x proxy.crawlera.com:8010 -U USER:PASS http://crawlera.com</pre>
+    <p>Using Crawlera is as easy as running following command:
+    <pre>  curl -x paygo.crawlera.com:8010 -U <API key>: http://www.food.com/</pre>
     <br /><br />
     <div style="text-align: center">
       <a class="redirect-button" href="http://scrapinghub.com/crawlera"><input type="submit" value="Learn More  "></a>


### PR DESCRIPTION
Updated the example to use API key authentication, changed endpoint to paygo.crawlera.com as proxy.crawlera.com is no longer used. Also changed the target URL due to crawlera.com redirect issue.
