### PR TITLE
Adding Crawlera docs link

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,9 @@ layout: default
     redirect to a captcha page. These responses are detected by Crawlera and the
     requests are automatically retried from another (clean) node.</p>
 
+    <p>Check <a href="#pricing-table">Pricing</a> below for the available plans and the <a href="http://doc.scrapinghub.com/crawlera.html">Documentation</a> to start using it.
+    </p>
+
     <h3>Features</h3>
     <ul>
       <li>Instant access to thousands of IPs in our shared pool.</li>
@@ -47,7 +50,7 @@ layout: default
 
     <p>Only successful downloads are charged.</p>
 
-    <h3>Pricing</h3>
+    <h3 id="pricing-table">Pricing</h3>
 
     <div class="plans-wrapper crawlera-plans">
 


### PR DESCRIPTION
As discussed in this ticket and doc:
- https://trello.com/c/XlmMz8NV/352-make-crawlera-docs-more-prominent
- https://docs.google.com/document/d/1NjHEp7yxA7llp8xI4xsRYhtE2cDmBoga6FZPQyIXFGc/edit#

As reported by user:
- https://trello.com/c/EM0joCsQ/88-put-the-detailed-crawlera-documentation-forward