### PR TITLE
Fix "Learn More" URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@ layout: default
 
     <br /><br />
     <div style="text-align: center">
-      <a class="redirect-button" href="http://scrapinghub.com/crawlera"><input type="submit" value="Learn More  "></a>
+      <a class="redirect-button" href="http://scrapinghub.com/crawlera/"><input type="submit" value="Learn More  "></a>
       <div class="button-divider"/>
         <a class="redirect-button" href="https://app.scrapinghub.com/account/signup/"><input type="submit" value="Sign Up "></a>
       </div>


### PR DESCRIPTION
Without that trailing slash I'm being redirected to http://scrapinghub.github.io/scrapinghub.com/crawlera/ with broken static assets link. Tested in FF 47.0.1 and Chrome 51.0
