### PR TITLE
Fix pricing, replacing 'mo' by 'month'

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@ layout: default
             <div class="plan-title">C10</div>
             <div class="plan-details">
                 <ul>
-                    <li><span class="mobile-only">Price: </span>$25/mo</li>
+                    <li><span class="mobile-only">Price: </span>$25/month</li>
                     <li><span class="mobile-only"> Monthly requests <span data-toggle="popover" data-trigger="hover" data-placement="top"  data-content="Only successful requests count towards the quota"><i class="fa fa-question-circle"></i></span>: </span> 150K</li>
                     <li><span class="mobile-only">Concurrent requests: </span>10</li>
                     <li><span class="mobile-only">Custom User agent: </span>-</li>
@@ -84,7 +84,7 @@ layout: default
             <div class="plan-title">C50</div>
             <div class="plan-details">
                 <ul>
-                    <li><span class="mobile-only">Price: </span>$100/mo</li>
+                    <li><span class="mobile-only">Price: </span>$100/month</li>
                     <li><span class="mobile-only"> Monthly requests <span data-toggle="popover" data-trigger="hover" data-placement="top"  data-content="Only successful requests count towards the quota"><i class="fa fa-question-circle"></i></span>: </span> 1M</li>
                     <li><span class="mobile-only">Concurrent requests: </span>50</li>
                     <li><span class="mobile-only">Custom User agent: </span>✔</li>
@@ -99,7 +99,7 @@ layout: default
             <div class="plan-title">C100</div>
             <div class="plan-details">
                 <ul>
-                    <li><span class="mobile-only">Price: </span>$250/mo</li>
+                    <li><span class="mobile-only">Price: </span>$250/month</li>
                     <li><span class="mobile-only"> Monthly requests <span data-toggle="popover" data-trigger="hover" data-placement="top"  data-content="Only successful requests count towards the quota"><i class="fa fa-question-circle"></i></span>: </span> 3M</li>
                     <li><span class="mobile-only">Concurrent requests: </span>100</li>
                     <li><span class="mobile-only">Custom User agent: </span>✔</li>
@@ -114,7 +114,7 @@ layout: default
             <div class="plan-title">C200</div>
             <div class="plan-details">
                 <ul>
-                    <li><span class="mobile-only">Price: </span>$500/mo</li>
+                    <li><span class="mobile-only">Price: </span>$500/month</li>
                     <li><span class="mobile-only"> Monthly requests <span data-toggle="popover" data-trigger="hover" data-placement="top"  data-content="Only successful requests count towards the quota"><i class="fa fa-question-circle"></i></span>: </span> 9M</li>
                     <li><span class="mobile-only">Concurrent requests: </span>200</li>
                     <li><span class="mobile-only">Custom User agent: </span>✔</li>


### PR DESCRIPTION
A customer mentioned that `$25/mo` might be interpreted as `25$/MB` by French and Romanian people, because mo stands for "mega-octet", which is usual there.

So, this PR changes occurrences of 'mo' with 'month'.
